### PR TITLE
Added python3 support and save functionality for hydra_export.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Custom created scripts for a better/faster experience at Synack Bug Bounty Platf
 ***Usages:***
 - Do not forgot to supply authorization headers for your user and target codename you want to process correctly while asked from command line.
 - Auth headers can be easily gathered from the web browser console with the command: `sessionStorage.getItem('shared-session-com.synack.accessToken');` while logged in. 
+- hydra_exports.py works both with python3 and python2 to use it simply $ python3 hydra_exports.py --key=<long stringhere> --codename=<codename of the target> the output will be displayed as well as saved in a file. 
 - Target codenames can also be easily gathered from URL, after clicking the target as: `https://platform.synack.com/targets/<target-codename>/scope`
 - For `scope_download_threaded.py` script, `max_page_count` should be increased if the target scope is too big. It can also be confirmed with the curl command: `curl -i -s -k  -X $'GET' -H $'Host: platform.synack.com' -H $'Authorization: Bearer <auth-token>' $'https://platform.synack.com/api/targets/<target-code>/cidrs?page=<max-page-count>'`. If it returns empty body while connected to the LP, then it can be said that the script covers all scope. No other configuration is needed for non-threaded `scope_download_normal.py` script.
 


### PR DESCRIPTION
You were using raw_input() which is not supported on python3 and also you were using both print '' and print() so that also rendered the script not to work with python3.

- I needed to use this so I added python3 support along with python2 used argparse and added some documentation.
- updated the Readme with instructions + help section in the script its self when you run it. 

:) 